### PR TITLE
Replace deprecated prettier option

### DIFF
--- a/dotfiles/_.prettierrc
+++ b/dotfiles/_.prettierrc
@@ -1,7 +1,7 @@
 {
   "arrowParens": "always",
   "bracketSpacing": true,
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "jsxSingleQuote": false,
   "printWidth": 100,
   "quoteProps": "as-needed",


### PR DESCRIPTION
[warn] jsxBracketSameLine is deprecated.
Ref: https://prettier.io/docs/en/options.html#deprecated-jsx-brackets